### PR TITLE
[RFT] (#32) - GET sensor list API is changed to use parameter

### DIFF
--- a/server/src/main/java/com/iieee/server/app/SensorApiController.java
+++ b/server/src/main/java/com/iieee/server/app/SensorApiController.java
@@ -1,6 +1,5 @@
 package com.iieee.server.app;
 
-import com.iieee.server.app.dto.sensor.SensorListRequestDto;
 import com.iieee.server.app.dto.sensor.SensorListResponseDto;
 import com.iieee.server.app.dto.sensor.SensorResponseDto;
 import com.iieee.server.app.dto.sensor.SensorSaveRequestDto;
@@ -8,6 +7,7 @@ import com.iieee.server.service.SensorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -25,8 +25,8 @@ public class SensorApiController {
     public SensorResponseDto findById(@PathVariable Long id) { return sensorService.findById(id); }
 
     @GetMapping("/stations/{station_id}")
-    public List<SensorListResponseDto> retrieveSensorListByDateTimeAndStation(@PathVariable Long station_id, @RequestBody SensorListRequestDto requestDto) {
-        return sensorService.findSensorListByDateTimeAndStation(station_id, requestDto);
+    public List<SensorListResponseDto> retrieveSensorListByDateTimeAndStation(@PathVariable Long station_id, @RequestParam String start, @RequestParam String end) {
+        return sensorService.findSensorListByDateTimeAndStation(station_id, LocalDateTime.parse(start), LocalDateTime.parse(end));
     }
 
     @GetMapping("/stations/{station_id}/1")

--- a/server/src/main/java/com/iieee/server/app/dto/sensor/SensorListRequestDto.java
+++ b/server/src/main/java/com/iieee/server/app/dto/sensor/SensorListRequestDto.java
@@ -8,6 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
+@Deprecated
 @NoArgsConstructor
 @Getter
 @Setter

--- a/server/src/main/java/com/iieee/server/service/SensorService.java
+++ b/server/src/main/java/com/iieee/server/service/SensorService.java
@@ -1,6 +1,5 @@
 package com.iieee.server.service;
 
-import com.iieee.server.app.dto.sensor.SensorListRequestDto;
 import com.iieee.server.app.dto.sensor.SensorListResponseDto;
 import com.iieee.server.app.dto.sensor.SensorResponseDto;
 import com.iieee.server.app.dto.sensor.SensorSaveRequestDto;
@@ -12,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -39,9 +39,9 @@ public class SensorService {
     }
 
     @Transactional(readOnly = true)
-    public List<SensorListResponseDto> findSensorListByDateTimeAndStation(Long station_id, SensorListRequestDto requestDto) {
+    public List<SensorListResponseDto> findSensorListByDateTimeAndStation(Long station_id, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         Station linkedStation = stationRepository.findById(station_id).orElseThrow(() -> new IllegalArgumentException("There is no station. id=" + station_id));
-        List<Sensor> entities = sensorRepository.findByDateTimeBetweenAndStation(requestDto.getStartDateTime(), requestDto.getEndDateTime(), linkedStation);
+        List<Sensor> entities = sensorRepository.findByDateTimeBetweenAndStation(startDateTime, endDateTime, linkedStation);
 
         if (entities.size() <= MAX_NUM_OF_INTERVAL) {
             return entities.stream()


### PR DESCRIPTION
## What?
날짜 범위에 맞는 센서 리스트를 제공하는 API가 Request body를 사용했는데 다른 방식으로 변경

## Why?
Front-end에서 axios를 사용해여, GET 요청에는 request body를 보낼 수 없음.

## How?
parameter를 사용하는 것으로 변경

## Testing?
Postman으로 테스트

## Screenshots (optional)
X


## Anything Else?
X 


## Reviewers
@iamhge 
