### PR TITLE
[FIX] (#45) - change the order of field in senetRequestDto

### DIFF
--- a/server/src/main/java/com/iieee/server/app/dto/network/ParseSenetRequestDto.java
+++ b/server/src/main/java/com/iieee/server/app/dto/network/ParseSenetRequestDto.java
@@ -29,8 +29,8 @@ public class ParseSenetRequestDto {
         return new SensorSaveRequestDto(
                 Double.parseDouble(valueList.get(1)),
                 Double.parseDouble(valueList.get(2)),
-                Double.parseDouble(valueList.get(3)),
                 Double.parseDouble(valueList.get(4)),
+                Double.parseDouble(valueList.get(3)),
                 this.dataTime
         );
     }


### PR DESCRIPTION
## What?
senet request dto를 sensor save request dto에 주입시키는 순서 변경

## Why?
네트워크 단에서 센서 저장하는 요청을 보낼 때 순서를 백엔드와 다르게 보냄.

## How?
senet 요청을 파싱한 리스트를 DTO에 넣는 순서를 변경함.

## Testing?
x

## Screenshots (optional)
X


## Anything Else?
X 


## Reviewers
@iamhge 
